### PR TITLE
Replace `append` with `appendChild` for IE11 compatibility

### DIFF
--- a/src/render/dom.ts
+++ b/src/render/dom.ts
@@ -10,7 +10,7 @@ const getHeadElement = (tagName: string, query: TagQueryKeys[]) => {
 }
 const createHeadElement = (tagName: string) => {
   const newTag = document.createElement(tagName)
-  document.head.append(newTag)
+  document.head.appendChild(newTag)
   return newTag
 }
 


### PR DESCRIPTION
`append` is not supported in IE11. In this case `appendChild` does exactly the same thing and is supported by IE11 :)